### PR TITLE
Calling count() on a query builder fails

### DIFF
--- a/src/Elkuent/Builder.php
+++ b/src/Elkuent/Builder.php
@@ -194,6 +194,9 @@ class Builder extends BaseBuilder {
     /**
      * Execute an aggregate function on the database.
      *
+     * @TODO Update to use aggregation key in the returned results
+     *       when aggregation support is added.
+     *
      * @param  string  $function
      * @param  array   $columns
      * @return mixed
@@ -209,12 +212,7 @@ class Builder extends BaseBuilder {
         // the aggregate value getting in the way when the grammar builds it.
         $this->columns = null; $this->aggregate = null;
 
-        if (isset($results[0]))
-        {
-            $result = (array) $results[0];
-
-            return $result['aggregate'];
-        }
+        return count($results);
     }
 
     /**


### PR DESCRIPTION
Fixes #2

Calling count() on a returned query builder fails because there is no
aggregate key in the returned results. Until aggregate search results are
supported return the total number of results by calling count on the
results.
