### PR TITLE
Enable elasticsearch aggregations

### DIFF
--- a/src/Elkuent/Builder.php
+++ b/src/Elkuent/Builder.php
@@ -37,7 +37,7 @@ class Builder extends BaseBuilder {
 
 
     /**
-     * Elastic search aggregation parameter
+     * Elasticsearch aggregation parameter
      * @var array
      */
     protected $aggregation;
@@ -221,7 +221,7 @@ class Builder extends BaseBuilder {
      * @param  array $aggregation PHP array representation of JSON aggregation object
      * @return void
      */
-    public function aggregateBy($aggregation) 
+    public function aggregateRaw($aggregation) 
     {
         $this->aggregation = $aggregation;
     }

--- a/src/Elkuent/EloquentBuilder.php
+++ b/src/Elkuent/EloquentBuilder.php
@@ -4,25 +4,10 @@ use Illuminate\Database\Eloquent\Builder as EBuilder;
 
 class Builder extends EBuilder {
 
-    // /**
-    //  * The methods that should be returned from query builder.
-    //  *
-    //  * @var array
-    //  */
-    // protected $passthru = array(
-    //     'toSql', 'lists', 'insert', 'insertGetId', 'pluck',
-    //     'count', 'min', 'max', 'avg', 'sum', 'exists', 'push', 'pull', 'getAggregation'
-    // );
-
     public function __construct($query) 
     {
         parent::__construct($query);
         array_push($this->passthru, 'getRawAggregation');
-    }
-
-    public function foo()
-    {
-        return 'we';
     }
 
 }

--- a/src/Elkuent/EloquentBuilder.php
+++ b/src/Elkuent/EloquentBuilder.php
@@ -4,15 +4,21 @@ use Illuminate\Database\Eloquent\Builder as EBuilder;
 
 class Builder extends EBuilder {
 
-    /**
-     * The methods that should be returned from query builder.
-     *
-     * @var array
-     */
-    protected $passthru = array(
-        'toSql', 'lists', 'insert', 'insertGetId', 'pluck',
-        'count', 'min', 'max', 'avg', 'sum', 'exists', 'push', 'pull', 'test'
-    );
+    // /**
+    //  * The methods that should be returned from query builder.
+    //  *
+    //  * @var array
+    //  */
+    // protected $passthru = array(
+    //     'toSql', 'lists', 'insert', 'insertGetId', 'pluck',
+    //     'count', 'min', 'max', 'avg', 'sum', 'exists', 'push', 'pull', 'getAggregation'
+    // );
+
+    public function __construct($query) 
+    {
+        parent::__construct($query);
+        array_push($this->passthru, 'getRawAggregation');
+    }
 
     public function foo()
     {

--- a/src/Elkuent/EloquentBuilder.php
+++ b/src/Elkuent/EloquentBuilder.php
@@ -1,0 +1,22 @@
+<?php namespace Elkuent\Eloquent;
+
+use Illuminate\Database\Eloquent\Builder as EBuilder;
+
+class Builder extends EBuilder {
+
+    /**
+     * The methods that should be returned from query builder.
+     *
+     * @var array
+     */
+    protected $passthru = array(
+        'toSql', 'lists', 'insert', 'insertGetId', 'pluck',
+        'count', 'min', 'max', 'avg', 'sum', 'exists', 'push', 'pull', 'test'
+    );
+
+    public function foo()
+    {
+        return 'we';
+    }
+
+}

--- a/src/Elkuent/EloquentModel.php
+++ b/src/Elkuent/EloquentModel.php
@@ -1,0 +1,21 @@
+<?php namespace Elkuent;
+
+use Elkuent\Builder;
+
+class EloquentModel extends \Illuminate\Database\Eloquent\Model {
+
+    /**
+     * Get a new query builder instance for the connection.
+     *
+     * @return Builder
+     */
+    protected function newBaseQueryBuilder()
+    {
+        var_dump('NEW QUERY');
+
+        $connection = $this->getConnection();
+
+        return new Builder($connection, $connection->getPostProcessor(), $this->index);
+    }
+
+}

--- a/src/Elkuent/EloquentModel.php
+++ b/src/Elkuent/EloquentModel.php
@@ -1,8 +1,9 @@
-<?php namespace Elkuent;
+<?php namespace Elkuent\Eloquent;
 
 use Elkuent\Builder;
+use Illuminate\Database\Eloquent\Model as EModel;
 
-class EloquentModel extends \Illuminate\Database\Eloquent\Model {
+class Model extends EModel {
 
     /**
      * Get a new query builder instance for the connection.
@@ -11,7 +12,6 @@ class EloquentModel extends \Illuminate\Database\Eloquent\Model {
      */
     protected function newBaseQueryBuilder()
     {
-        var_dump('NEW QUERY');
 
         $connection = $this->getConnection();
 

--- a/src/Elkuent/Model.php
+++ b/src/Elkuent/Model.php
@@ -2,12 +2,12 @@
 
 // use Elkuent\Builder;
 use Elkuent\Eloquent\Builder;
-use Elkuent\EloquentModel;
+use Elkuent\Eloquent\Model as EModel;
 
 use Carbon\Carbon;
 use DateTime;
 
-class Model extends EloquentModel {
+class Model extends EModel {
 
     protected $index = null;
 

--- a/src/Elkuent/Model.php
+++ b/src/Elkuent/Model.php
@@ -1,6 +1,5 @@
 <?php namespace Elkuent;
 
-// use Elkuent\Builder;
 use Elkuent\Eloquent\Builder;
 use Elkuent\Eloquent\Model as EModel;
 
@@ -183,20 +182,6 @@ class Model extends EModel {
 
         parent::setAttribute($key, $value);
     }
-
-    /**
-     * Get a new query builder instance for the connection.
-     *
-     * @return Builder
-     */
-     /*
-    protected function newBaseQueryBuilder()
-    {
-        $connection = $this->getConnection();
-
-        return new Builder($connection, $connection->getPostProcessor(), $this->index);
-    }
-    */
 
     /**
      * Create a new Eloquent query builder for the model.

--- a/src/Elkuent/Model.php
+++ b/src/Elkuent/Model.php
@@ -1,11 +1,13 @@
 <?php namespace Elkuent;
 
-use Elkuent\Builder;
+// use Elkuent\Builder;
+use Elkuent\Eloquent\Builder;
+use Elkuent\EloquentModel;
 
 use Carbon\Carbon;
 use DateTime;
 
-class Model extends \Illuminate\Database\Eloquent\Model {
+class Model extends EloquentModel {
 
     protected $index = null;
 
@@ -187,11 +189,22 @@ class Model extends \Illuminate\Database\Eloquent\Model {
      *
      * @return Builder
      */
+     /*
     protected function newBaseQueryBuilder()
     {
         $connection = $this->getConnection();
 
         return new Builder($connection, $connection->getPostProcessor(), $this->index);
+    }
+    */
+
+    /**
+     * Create a new Eloquent query builder for the model.
+     *
+     */
+    public function newEloquentBuilder($query)
+    {
+        return new Builder($query);
     }
 
     /**


### PR DESCRIPTION
Usage:

```
        $e = new EndpointUsage();
        $usageTotals = $e->whereIn('consumer_id', $consumerIds)->where('http_status_code', 200)->where('@timestamp', 'between', [$start, $end] )->aggregateBy( [
            "by_app" => [
                "terms" => [
                    "field" => "consumer_id"
                ],
                "aggs" => [
                    "by_method" => [
                       "terms" => [
                          "field" => "request_method"
                       ]
                    ]
                ]
            ]
        ])->getRawAggregation();
```

Note that `Elkuent\Eloquent\Builder` was introduced in the inheritance chain to include `getRawAggregation` as a `$passthru` method so that the result can be returned, and not the Builder. 

See method: `__call()` of `\Illuminate\Database\Eloquent\Builder`
