### PR TITLE
Bug fix: "between" range

### DIFF
--- a/src/Elkuent/Builder.php
+++ b/src/Elkuent/Builder.php
@@ -84,8 +84,8 @@ class Builder extends BaseBuilder {
                 return array(
                     'range' => array(
                         $column => array(
-                            'lte' => $value[0],
-                            'gte' => $value[1]
+                            'gte' => $value[0],
+                            'lte' => $value[1]
                         )
                     )
                 );},


### PR DESCRIPTION
Switched order of the range values. Intuitively the input should be `[lower, upper]` bounds of the range.
