### PR TITLE
Add nested column type to Blueprint

### DIFF
--- a/src/Elkuent/Schema/Blueprint.php
+++ b/src/Elkuent/Schema/Blueprint.php
@@ -44,6 +44,11 @@ class Blueprint extends SchemaBlueprint
         return $this->addColumn('geo_shape', $column, $attributes);
     }
 
+    public function nested($column, $attributes = array())
+    {
+        return $this->addColumn('nested', $column, $attributes);
+    }
+
     public function toSql(Connection $connection, Grammar $grammar)
     {
         throw new Exception('Call to undefined method.');


### PR DESCRIPTION
Add the nested column type method to the Blueprint so the index template
mapping gets set correctly. Fixes #35 
